### PR TITLE
Fix front camera mirroring

### DIFF
--- a/client/src/pages/room.tsx
+++ b/client/src/pages/room.tsx
@@ -25,6 +25,7 @@ export default function Room() {
   const localStream = useRef<MediaStream>();
   const dataChannel = useRef<RTCDataChannel>();
   const [localCircleColor, setLocalCircleColor] = useState<string>(`hsl(${Math.random() * 360}, 70%, 60%)`); // Added state for local user's circle color
+  const [facingMode, setFacingMode] = useState<"user" | "environment" | null>(null);
 
   useEffect(() => {
     const initializeMedia = async () => {
@@ -36,6 +37,11 @@ export default function Room() {
         localStream.current = stream;
         if (localVideoRef.current) {
           localVideoRef.current.srcObject = stream;
+        }
+
+        const trackFacingMode = stream.getVideoTracks()[0]?.getSettings().facingMode;
+        if (trackFacingMode === "user" || trackFacingMode === "environment") {
+          setFacingMode(trackFacingMode);
         }
 
         const { pc } = await setupPeerConnection(
@@ -133,6 +139,8 @@ export default function Room() {
           localVideoRef.current.srcObject = screenStream;
         }
 
+        setFacingMode(null);
+
         // Handle when user stops sharing screen
         videoTrack.onended = () => {
           toggleScreenShare();
@@ -158,6 +166,11 @@ export default function Room() {
 
         if (localVideoRef.current) {
           localVideoRef.current.srcObject = stream;
+        }
+
+        const trackFacingMode = stream.getVideoTracks()[0]?.getSettings().facingMode;
+        if (trackFacingMode === "user" || trackFacingMode === "environment") {
+          setFacingMode(trackFacingMode);
         }
 
         setIsScreenSharing(false);
@@ -194,6 +207,10 @@ export default function Room() {
         if (localVideoRef.current) {
           localVideoRef.current.srcObject = newStream;
         }
+        const trackFacingMode = newStream.getVideoTracks()[0]?.getSettings().facingMode;
+        if (trackFacingMode === "user" || trackFacingMode === "environment") {
+          setFacingMode(trackFacingMode);
+        }
 
         localStream.current = newStream;
       }
@@ -224,6 +241,7 @@ export default function Room() {
               muted
               playsInline
               className={cn("w-full h-full object-cover", isVideoOff && "hidden")}
+              style={{ transform: facingMode === "user" ? "scaleX(-1)" : "none" }}
             />
             {isVideoOff && (
               <div className="w-full h-full flex items-center justify-center">


### PR DESCRIPTION
## Summary
- detect camera facing mode and store it in state
- flip the local video when using the front camera
- update facing mode when switching camera and when toggling screen share

## Testing
- `npm run check` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_68691aca10548331a4f388991d623ce2