### PR TITLE
Fix TypeScript error and add dark mode toggle

### DIFF
--- a/client/src/components/theme-toggle.tsx
+++ b/client/src/components/theme-toggle.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+import { Switch } from "./ui/switch";
+
+export default function ThemeToggle() {
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("theme");
+    if (stored === "dark") {
+      document.documentElement.classList.add("dark");
+      setEnabled(true);
+    }
+  }, []);
+
+  const toggle = (checked: boolean) => {
+    setEnabled(checked);
+    if (checked) {
+      document.documentElement.classList.add("dark");
+      localStorage.setItem("theme", "dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+      localStorage.setItem("theme", "light");
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <Switch id="theme-toggle" checked={enabled} onCheckedChange={toggle} />
+      <label htmlFor="theme-toggle" className="text-sm">
+        Dark mode
+      </label>
+    </div>
+  );
+}

--- a/client/src/lib/webrtc.ts
+++ b/client/src/lib/webrtc.ts
@@ -85,7 +85,8 @@ export async function startScreenShare(): Promise<MediaStream> {
   return await navigator.mediaDevices.getDisplayMedia({
     video: {
       displaySurface: "monitor", // Prefer full screen
-      logicalSurface: true,
+      // `logicalSurface` is not yet part of the TypeScript DOM lib, so cast to any
+      ...( { logicalSurface: true } as any ),
       cursor: "always"
     },
     audio: true

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { apiRequest } from "@/lib/queryClient";
 import { Video, Users } from "lucide-react";
+import ThemeToggle from "@/components/theme-toggle";
 import { useToast } from "@/hooks/use-toast";
 
 export default function Home() {
@@ -92,11 +93,12 @@ export default function Home() {
   return (
     <div className="min-h-screen bg-background flex items-center justify-center p-4">
       <Card className="w-full max-w-md">
-        <CardHeader>
-          <CardTitle className="text-2xl font-bold text-center flex items-center justify-center gap-2">
+        <CardHeader className="flex items-center justify-between">
+          <CardTitle className="text-2xl font-bold flex items-center gap-2">
             <Video className="w-6 h-6" />
             Video Chat
           </CardTitle>
+          <ThemeToggle />
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="space-y-2">


### PR DESCRIPTION
## Summary
- fix `logicalSurface` TypeScript error in `webrtc.ts`
- add a `ThemeToggle` component for dark mode switching
- display the theme toggle on the home page header

## Testing
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686a42d1bb7c8331845dabeba2c42465